### PR TITLE
Fix for double strongs references

### DIFF
--- a/schema/usx.rnc
+++ b/schema/usx.rnc
@@ -607,7 +607,7 @@ CharWithAttrib.char.style.w =
         char.link?,
         char.closed?,
         attribute lemma { xsd:string { minLength = "1" } }?, # Lemma/citation form found in glossary
-        attribute strong { xsd:string { pattern = "[HG]\d{4,5}(:[a-z])?"} }?, # Strong’s ID in the form H##### (Hebrew) or G##### (Greek)
+        attribute strong { xsd:string { pattern = "([HG]\d{4,5}(:[a-z])?,?)+"} }?, # Strong’s ID in the form H##### (Hebrew) or G##### (Greek)
         attribute srcloc { xsd:string { pattern = "[a-z]{3,5}\d?:\d+\.\d+\.\d+\.\d+" } }?, # Location of the word in the source text
         text,
         (Reference | Char | Milestone | Footnote | Break | text)* # Nested character <char> markup

--- a/schema/usx.rng
+++ b/schema/usx.rng
@@ -1286,7 +1286,7 @@
           <!-- Lemma/citation form found in glossary -->
           <attribute name="strong">
             <data type="string">
-              <param name="pattern">[HG]\d{4,5}(:[a-z])?</param>
+              <param name="pattern">([HG]\d{4,5}(:[a-z])?,?)+</param>
             </data>
           </attribute>
         </optional>


### PR DESCRIPTION
The [char documentation for w](https://ubsicap.github.io/usx/usx3.0/charstyles.html#w) states that the strongs references allow multiple numbers per attribute. 

`strong="H01234,G05485"`

However the regex doesn't match this use case.

**Changing Line 610 of the [rnc](https://github.com/ubsicap/usx/blob/master/schema/usx.rnc) from** 

`attribute strong { xsd:string { pattern = "[HG]\d{4,5}(:[a-z])?"} }?`
 
to:

`attribute strong { xsd:string { pattern = "([HG]\d{4,5}(:[a-z])?,?)+"} }?`

Fixes this